### PR TITLE
Update Ozone Analytics Queries to `1.4.0-SNAPSHOT`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
     <!-- Ozone -->
     <distro.ozoneTempConfigDir>${distro.baseDir}/ozone_config_temp</distro.ozoneTempConfigDir>
     <ozoneConfigVersion>1.5.0</ozoneConfigVersion>
-    <analyticsQueriesVersion>1.3.0-SNAPSHOT</analyticsQueriesVersion>
+    <analyticsQueriesVersion>1.4.0-SNAPSHOT</analyticsQueriesVersion>
 
   </properties>
 


### PR DESCRIPTION
This PR updates the Ozone Analytics Queries to 1.4.0-SNAPSHOT.